### PR TITLE
Added migration hint for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Next, apply NetBox's database migrations using the `migrate` management command.
 ```bash
 source /opt/netbox/venv/bin/activate
 ./manage.py migrate
+
+# Netbox Docker
+docker-compose exec netbox bash -c "source /opt/netbox/venv/bin/activate && ./manage.py migrate"
 ```
 
 Finally, load the demo data fixtures from the JSON file.


### PR DESCRIPTION
Without the migration step, the import step in the Docker version would not work.