### PR TITLE
chore: add v2 docker compose and exclude django_rq

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,15 @@ source /opt/netbox/venv/bin/activate
 
 ### Docker Commands
 
+Docker Compose v1
+
+```bash
+docker-compose exec netbox bash -c "source /opt/netbox/venv/bin/activate && ./manage.py dumpdata --natural-foreign --natural-primary -e extras.Script -e extras.Report -e extras.ObjectChange -e django_rq --indent 2" > netbox-demo-$VERSION.json
 ```
-docker-compose exec netbox bash -c "source /opt/netbox/venv/bin/activate && ./manage.py dumpdata --natural-foreign --natural-primary -e extras.Script -e extras.Report -e extras.ObjectChange --indent 2" > netbox-demo-$VERSION.json
+
+Docker Compose v2
+
+```bash
+docker compose exec netbox bash -c "source /opt/netbox/venv/bin/activate && ./manage.py dumpdata -e extras.Script -e extras.Report -e extras.ObjectChange -e django_rq --indent 2 --output netbox-demo-$VERSION.json"
 ```
 


### PR DESCRIPTION
Running the commands listed in README.md doesn't work on netbox 3.4.7, I think due to some django-rq model changes. If you don't use the excluded I added, you get the following error: 

```
CommandError: Unable to serialize database: relation "django_rq_queue" does not exist
LINE 1: SELECT COUNT(*) AS "__count" FROM "django_rq_queue"
```

I also added a docker compose v2 example, since that is The Way of the Future. Feel free to nuke that line if you want.