### PR TITLE
Update docker instructions for postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ docker-compose exec postgres sh -c 'psql -U $POSTGRES_USER postgres -c "DROP DAT
 docker-compose exec postgres sh -c 'psql -U $POSTGRES_USER postgres -c "CREATE DATABASE netbox;"'
 
 # Load the demo data
-docker cp netbox-demo-$VERSION.sql "$(docker-compose ps -q netbox)":/opt/netbox/netbox/netbox-demo.sql
-docker-compose exec netbox bash -c "psql -U $POSTGRES_USER netbox < /opt/netbox/netbox/netbox-demo.sql"
+docker cp netbox-demo-$VERSION.sql "$(docker-compose ps -q postgres)":/tmp/netbox-demo.sql
+docker-compose exec postgres sh -c "psql -U $POSTGRES_USER netbox < /tmp/netbox-demo.sql"
 ```
 
 ## Exporting the Data


### PR DESCRIPTION
The default https://github.com/netbox-community/netbox-docker docker-compose file spins up a postgres container for database. This PR updates readme instructions for most likely use case with switch to loading pg_dump files